### PR TITLE
Pip Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ See the full BERT-RPC specification at [bert-rpc.org](http://bert-rpc.org).
 Installation
 ------------
 
-To install Python-Ernie, you will also need to install the Python port of BERT serializers and Erlastic.
+To install Python-Ernie, you can use pip or traditional setup.py:
+
+    $ pip install git+git://github.com/krobertson/python-ernie 
+
+pip will install all the dependencies for you which you have to do by yourself when using setup.py directly. This means you need to install the Python port of BERT serializers and Erlastic.
 
     $ git clone git://github.com/samuel/python-erlastic.git
     $ sudo python python-erlastic/setup.py install

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
-import bert
+from bert import __version__ as version
 
-__version__ = bert.__version__
-
+__version__ = version
 
 setup(
     name = 'ernie',
@@ -19,5 +18,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
-    ],
+    ], 
+    install_requires = ["bert>=2.0.0"],
+	dependency_links = [
+		'http://github.com/samuel/python-bert/tarball/master#egg=bert-2.0.0'
+	]
 )

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,27 @@
 
 from distutils.core import setup
 
+# The original author of this library is
+# Ken Robertson ken@invalidlogic.com
+# This version is a fork on github maintained by
+# Andre Graf andre@dergraf.org.
+#
+# Ken's library version number depended on
+# the version number of python-bert. This is
+# not suitable for an automated installation
+# using pip which will automatically install 
+# the dependencies listed in 'install_requires'.
+# For this reason I manually set the version
+# number.
 __version__ = '1.0.0'
 
 setup(
     name = 'ernie',
     version = __version__,
     description = 'BERT-Ernie Library',
-    author = 'Ken Robertson',
-    author_email = 'ken@invalidlogic.com',
-    url = 'http://invalidlogic.com',
+    author = 'Andre Graf',
+    author_email = 'andre@dergraf.org',
+    url = 'http://github.com/dergraf/python-ernie',
     packages = ['ernie'],
     classifiers = [
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
-from bert import __version__ as version
 
-__version__ = version
+__version__ = '1.0.0'
 
 setup(
     name = 'ernie',

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
-from bert import __version__ as version
 
-__version__ = version
+__version__ = 1.0.0
 
 setup(
     name = 'ernie',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ], 
     install_requires = ["bert>=2.0.0"],
-	dependency_links = [
-		'http://github.com/samuel/python-bert/tarball/master#egg=bert-2.0.0'
-	]
+    dependency_links = [
+        'http://github.com/samuel/python-bert/tarball/master#egg=bert-2.0.0'
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
+import bert
 
-from bert import __version__ as version
+__version__ = bert.__version__
+
 
 setup(
     name = 'ernie',
-    version = version,
+    version = __version__,
     description = 'BERT-Ernie Library',
     author = 'Ken Robertson',
     author_email = 'ken@invalidlogic.com',


### PR DESCRIPTION
I changed your setup.py in a way that python-ernie can be fetched and installed using pip. The problem was your <code>from bert import **version** as version</code> in setup.py which pip is not able to resolve. 

In order to install python-ernie using pip you need to tell pip to fetch it from your github repo, however you may consider uploading the package to pypi.

I changed the Readme, so the readers know that they can also use pip
