### PR TITLE
Threaded version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ To install python-ernie itself, run:
 
 Example Handler
 ---------------
-This is a (new) threaded version, which will serve multiple conections on parallel, there is more than one way to use it.
-The non-locking and the locking way. The non-locking way will start the BERT-RPC server and return the program control
-to the subsecuent lines of code, it will be the responsability of the user to keep the program using the library running.
+This is a (new) threaded version, which will serve multiple conections on parallel. There is more than one way to use it,
+the non-locking and the locking way. The non-locking way will start the BERT-RPC server and return the program control
+to the subsequent lines of code, it will be the responsability of the user to keep the program using the library running.
 Calling the start() method of the service/library on a non-locking manner and do nothing will fail to keep the server running
 since the main process will finish and with it the RPC server thread.
 
@@ -81,8 +81,6 @@ Just create your own fork, hack on it, and then send me a pull request once done
 Todo
 ---------
 
-I'll be the first to admin I am still new to Python.  So if I am way off on best practices in Python, let me know!
-
 1. Separate library functionality (transport agnostic) from implemented service.
 1. Update exception handling to return traceback
 1. Ensure correct handling around read operations
@@ -92,7 +90,7 @@ I'll be the first to admin I am still new to Python.  So if I am way off on best
 Credits
 ---------
 
-* [@krobertson](https://github.com/krobertson) for original port of python-ernie
+* [@krobertson](https://github.com/krobertson) for original Ruby port and authoring python-ernie
 * [@mojombo](https://github.com/mojombo) for BERT/Ernie
 * [@samuel](https://github.com/samuel) for python-bert
 * [@dergraf](https://github.com/dergraf) for pip compatibility

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 Python-Ernie
 =====
-
 Original Ruby port by Ken Robertson (ken@invalidlogic.com)
 
 Python-Ernie is a (now threaded) port of the Ruby-based Ernie server by Tom Preston-Werner. Python-Ernie is the Python server implementation for the BERT-RPC specification. Threaded version implemented by Miguel Paolino (miguel@paolino.com.uy).
@@ -31,12 +30,12 @@ To install python-ernie itself, run:
 Example Handler
 ---------------
 This is a (new) threaded version, which will serve multiple conections on parallel. There is more than one way to use it,
-the non-locking and the locking way. The non-locking way will start the BERT-RPC server and return the program control
+the non-blocking and the blocking way. The non-blocking way will start the BERT-RPC server and return the program control
 to the subsequent lines of code, it will be the responsability of the user to keep the program using the library running.
-Calling the start() method of the service/library on a non-locking manner and do nothing will fail to keep the server running
+Calling the start() method of the service/library on a non-blocking manner and do nothing will fail to keep the server running
 since the main process will finish and with it the RPC server thread.
 
-Non locking server example
+Non blocking server example
 --------------------------
 
 
@@ -51,7 +50,7 @@ Non locking server example
         while True:
             time.sleep(100)
 
-Locking server example 
+Blocking server example 
 ----------------------
 
 
@@ -79,7 +78,7 @@ Just create your own fork, hack on it, and then send me a pull request once done
 Todo
 ---------
 
-1. Separate library functionality (transport agnostic) from implemented service.
+1. Better separate library functionality (transport agnostic) from implemented service.
 1. Update exception handling to return traceback
 1. Ensure correct handling around read operations
 1. See if I can clean up the way you define your modules
@@ -97,6 +96,7 @@ License
 ---------
 
 Copyright (c) 2012 Miguel Paolino
+
 Copyright (c) 2009 Ken Robertson
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Python-Ernie
 
 By Ken Robertson (ken@invalidlogic.com)
 
-Python-Ernie is a port of the Ruby-based Ernie server by Tom Preston-Werner.  Python-Ernie is the Python server implementation for the BER-RPC specification.
+Python-Ernie is a (now threaded) port of the Ruby-based Ernie server by Tom Preston-Werner. Python-Ernie is the Python server implementation for the BER-RPC specification. Threaded version implemented by Miguel Paolino (miguel@paolino.com.uy).
 
 See the full BERT-RPC specification at [bert-rpc.org](http://bert-rpc.org).
 
@@ -13,7 +13,7 @@ Installation
 
 To install Python-Ernie, you can use pip or traditional setup.py:
 
-    $ pip install git+git://github.com/krobertson/python-ernie 
+    $ pip install git+git://github.com/mpaolino/python-ernie 
 
 pip will install all the dependencies for you which you have to do by yourself when using setup.py directly. This means you need to install the Python port of BERT serializers and Erlastic.
 
@@ -30,6 +30,30 @@ To install python-ernie itself, run:
 
 Example Handler
 ---------------
+This is a (new) threaded version, which will serve multiple conections on parallel, there is more than one way to use it.
+The non-locking and the locking way. The non-locking way will start the BERT-RPC server and return the program control
+to the subsecuent lines of code, it will be the responsability of the user to keep the program using the library running.
+Calling the start() method of the service/library on a non-locking manner and do nothing will fail to keep the server running
+since the main process will finish and with it the RPC server thread.
+
+Non locking server example
+--------------------------
+
+from ernie import mod, start
+
+    from ernie import mod, start
+    
+    def calc_add(a, b):
+        return a + b
+    mod('calc').fun('add', calc_add)
+    
+    if __name__ == "__main__":
+        start(daemon=True)
+        while True:
+            time.sleep(100)
+
+Locking server example 
+----------------------
 
 from ernie import mod, start
 
@@ -43,12 +67,13 @@ from ernie import mod, start
         start()
 
 
+
 Contribute
 ----------
 
 If you'd like to hack on Python-Ernie, start by forking my repo on GitHub:
 
-http://github.com/krobertson/python-ernie
+http://github.com/mpaolino/python-ernie
 
 Just create your own fork, hack on it, and then send me a pull request once done.
 
@@ -58,23 +83,24 @@ Todo
 
 I'll be the first to admin I am still new to Python.  So if I am way off on best practices in Python, let me know!
 
+1. Separate library functionality (transport agnostic) from implemented service.
 1. Update exception handling to return traceback
 1. Ensure correct handling around read operations
 1. See if I can clean up the way you define your modules
 1. Test
 
-
 Credits
 ---------
 
+* [@krobertson](https://github.com/krobertson) for original port of python-ernie
 * [@mojombo](https://github.com/mojombo) for BERT/Ernie
 * [@samuel](https://github.com/samuel) for python-bert
 * [@dergraf](https://github.com/dergraf) for pip compatibility
 
-
 License
 ---------
 
+Copyright (c) 2012 Miguel Paolino
 Copyright (c) 2009 Ken Robertson
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 Python-Ernie
 =====
 Original Ruby port by Ken Robertson (ken@invalidlogic.com)
+Threaded/forking version implemented by Miguel Paolino (miguel@paolino.com.uy).
 
-Python-Ernie is a (now threaded) port of the Ruby-based Ernie server by Tom Preston-Werner. Python-Ernie is the Python server implementation for the BERT-RPC specification. Threaded version implemented by Miguel Paolino (miguel@paolino.com.uy).
+python-ernie is a (now a sync and async) port of the Ruby-based Ernie server by Tom Preston-Werner. Python-Ernie is the Python server implementation for the BERT-RPC specification. The default request serving method is sync and secuential, this version also gives the possibility to serve requests in a async (parallel) fashion using threads or forks.
 
 See the full BERT-RPC specification at [bert-rpc.org](http://bert-rpc.org).
 
@@ -10,7 +11,7 @@ See the full BERT-RPC specification at [bert-rpc.org](http://bert-rpc.org).
 Installation
 ------------
 
-To install Python-Ernie, you can use pip or traditional setup.py:
+To install python-ernie, you can use pip or traditional setup.py:
 
     $ pip install git+git://github.com/mpaolino/python-ernie 
 
@@ -29,14 +30,12 @@ To install python-ernie itself, run:
 
 Example Handler
 ---------------
-This is a (new) threaded version, which will serve multiple conections on parallel. There is more than one way to use it,
-the non-blocking and the blocking way. The non-blocking way will start the BERT-RPC server and return the program control
-to the subsequent lines of code, it will be the responsability of the user to keep the program using the library running.
+There is more than one way to use ernie, the non-blocking and the blocking way. The non-blocking way will start the BERT-RPC server and return the program control to subsequent lines of code, it will be the responsability of the user to keep the program using the library running. This comes in handy when you need to do other stuff besides serving BERT-RPC.
 Calling the start() method of the service/library on a non-blocking manner and do nothing will fail to keep the server running
-since the main process will finish and with it the RPC server thread.
+since the main process will finish and with it the child RPC server thread/process.
 
 Non blocking server example
---------------------------
+---------------------------
 
 
     from ernie import mod, start
@@ -63,12 +62,28 @@ Blocking server example
     if __name__ == "__main__":
         start()
 
+async
+-----
+To serve request asynchronously you can choose to use threads or forking processes. Forking has the advantage of using all the underlying available CPUs of the system. Threads will use all the CPUs but will compete por the GIL making the computation time similar -if not worst- to serial execution time for CPU-bound tasks. You are not exempt from doing your share of thinking, functions that execute in parallel on threads or processes will have to be designed to do so. Also, beware of libraries that are not thread-safe, those will not work with ernie threads.
+
+To use the async mode you pass several arguments to the start function.
+
+
+    start(daemon=False, host='', port=50007, async=False, forking=False)
+
+    Parameters:
+    
+    daemon  - Blocking/non-blocking ernie server. Defaults to False, blocking mode.
+    host    - Host (IP) to bind. Empty string means all IPs, defaults to all IPs.
+    port    - TCP port to bind to.
+    async   - Run in async mode. Defaults to False, meaning sync mode.
+    forking - Use forks for async. Defaults to False, meaning threads.
 
 
 Contribute
 ----------
 
-If you'd like to hack on Python-Ernie, start by forking my repo on GitHub:
+If you'd like to hack on python-ernie, start by forking my repo on GitHub:
 
 http://github.com/mpaolino/python-ernie
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Python-Ernie
 
 Original Ruby port by Ken Robertson (ken@invalidlogic.com)
 
-Python-Ernie is a (now threaded) port of the Ruby-based Ernie server by Tom Preston-Werner. Python-Ernie is the Python server implementation for the BER-RPC specification. Threaded version implemented by Miguel Paolino (miguel@paolino.com.uy).
+Python-Ernie is a (now threaded) port of the Ruby-based Ernie server by Tom Preston-Werner. Python-Ernie is the Python server implementation for the BERT-RPC specification. Threaded version implemented by Miguel Paolino (miguel@paolino.com.uy).
 
 See the full BERT-RPC specification at [bert-rpc.org](http://bert-rpc.org).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Python-Ernie
 =====
 
-By Ken Robertson (ken@invalidlogic.com)
+Original Ruby port by Ken Robertson (ken@invalidlogic.com)
 
 Python-Ernie is a (now threaded) port of the Ruby-based Ernie server by Tom Preston-Werner. Python-Ernie is the Python server implementation for the BER-RPC specification. Threaded version implemented by Miguel Paolino (miguel@paolino.com.uy).
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ since the main process will finish and with it the RPC server thread.
 Non locking server example
 --------------------------
 
-from ernie import mod, start
 
     from ernie import mod, start
     
@@ -55,7 +54,6 @@ from ernie import mod, start
 Locking server example 
 ----------------------
 
-from ernie import mod, start
 
     from ernie import mod, start
     

--- a/ernie/__init__.py
+++ b/ernie/__init__.py
@@ -3,19 +3,20 @@
 
 __version__ = "0.0.1"
 
-from ernie import ThreadedErnie, Ernie
+from ernie import ErnieServer, Ernie
 
 
 def mod(name):
     return Ernie.mod(name)
 
 
-def start(daemon=False, host='', port=50007):
+def start(daemon=False, host='', port=50007, forking=False, async=False):
     '''
         Starts a Ernie server on given interface and port.
         If daemon is True the server will start on a separate thread
         and return immediately, otherwise it will never return
         until killed.
     '''
-    server = ThreadedErnie()
-    server.start(daemon=daemon, host=host, port=port)
+    server = ErnieServer(daemon=daemon, host=host, port=port, forking=forking,
+                         async=async)
+    server.start()

--- a/ernie/__init__.py
+++ b/ernie/__init__.py
@@ -3,12 +3,19 @@
 
 __version__ = "0.0.1"
 
-import bert
-from ernie import Ernie, Mod
+from ernie import ThreadedErnie, Ernie
+
 
 def mod(name):
     return Ernie.mod(name)
 
-def start():
-    server = Ernie()
-    server.start()
+
+def start(daemon=False, host='', port=50007):
+    '''
+        Starts a Ernie server on given interface and port.
+        If daemon is True the server will start on a separate thread
+        and return immediately, otherwise it will never return
+        until killed.
+    '''
+    server = ThreadedErnie()
+    server.start(daemon=daemon, host=host, port=port)

--- a/ernie/ernie.py
+++ b/ernie/ernie.py
@@ -137,4 +137,4 @@ class ThreadedErnie(object):
         # Kill all threads or wait for them to finnish on exit, False = wait
         server_thread.daemon_threads = kill_threads
         server_thread.start()
-        print "Server running..."
+        print "Ernie server running on %s:%s" % (host, port)

--- a/ernie/ernie.py
+++ b/ernie/ernie.py
@@ -1,107 +1,140 @@
-import inspect
-import sys
-import os
 import logging
 import bert
 import struct
+import threading
+import SocketServer
+
+
+class ErnieTCPHandler(SocketServer.StreamRequestHandler):
+
+    def handle(self):
+        ernie_inst = Ernie()
+        # self.rfile is a file-like object created by the handler;
+        # we can now use e.g. readline() instead of raw recv() calls
+        ernie_inst.handle_input(self.rfile, self.wfile)
+
 
 class Ernie(object):
     mods = {}
     logger = None
-    
+
     @classmethod
     def mod(cls, name):
-        if cls.mods.has_key(name) == False:
+        if name not in cls.mods:
             cls.mods[name] = Mod(name)
         return cls.mods[name]
-    
+
     @classmethod
     def logfile(cls, file):
-        logging.basicConfig(filename=file,level=logging.DEBUG)
+        logging.basicConfig(filename=file, level=logging.DEBUG)
         cls.logger = logging.getLogger('ernie')
-    
+
     @classmethod
     def log(cls, text):
         if cls.logger != None:
             cls.logger.debug(text)
-    
+
     def dispatch(self, mod, fun, args):
-        if Ernie.mods.has_key(mod) == False:
+        if mod not in Ernie.mods:
             raise ServerError("No such module '" + mod + "'")
-        if Ernie.mods[mod].funs.has_key(fun) == False:
+        if fun not in Ernie.mods[mod].funs:
             raise ServerError("No such function '" + mod + ":" + fun + "'")
         return Ernie.mods[mod].funs[fun](*args)
-    
+
     def read_4(self, input):
         raw = input.read(4)
         if len(raw) == 0:
             return None
         return struct.unpack('!L', raw)[0]
-    
+
     def read_berp(self, input):
         packet_size = self.read_4(input)
         if packet_size == None:
             return None
         ber = input.read(packet_size)
         return bert.decode(ber)
-    
+
     def write_berp(self, output, obj):
         data = bert.encode(obj)
         output.write(struct.pack("!L", len(data)))
         output.write(data)
         output.flush()
-    
-    def start(self):
-        Ernie.log("Starting")
-        input = os.fdopen(3)
-        output = os.fdopen(4, "w")
-        
-        while(True):
-            ipy = self.read_berp(input)
-            if ipy == None:
-                print 'Could not read BERP length header. Ernie server may have gone away. Exiting now.'
-                exit()
-            
-            if len(ipy) == 4 and ipy[0] == bert.Atom('call'):
-                mod, fun, args = ipy[1:4]
-                self.log("-> " + ipy.__str__())
-                try:
-                    res = self.dispatch(mod, fun, args)
-                    opy = (bert.Atom('reply'), res)
-                    self.log("<- " + opy.__str__())
-                    self.write_berp(output, opy)
-                except ServerError, e:
-                    opy = (bert.Atom('error'), (bert.Atom('server'), 0, str(type(e)), str(e), ''))
-                    self.log("<- " + opy.__str__())
-                    self.write_berp(output, opy)
-                except Exception, e:
-                    opy = (bert.Atom('error'), (bert.Atom('user'), 0, str(type(e)), str(e), ''))
-                    self.log("<- " + opy.__str__())
-                    self.write_berp(output, opy)
-            elif len(ipy) == 4 and ipy[0] == bert.Atom('cast'):
-                mod, fun, args = ipy[1:4]
-                self.log("-> " + ipy.__str__())
-                try:
-                    res = self.dispatch(mod, fun, args)
-                except:
-                    pass
-                self.write_berp(output, (bert.Atom('noreply')))
-            else:
-                self.log("-> " + ipy.__str__())
-                opy = (bert.Atom('error'), (bert.Atom('server'), 0, "Invalid request: " + ipy.__str__()))
+
+    def handle_input(self, input, output):
+        ipy = self.read_berp(input)
+        if ipy == None:
+            print 'Could not read BERP length header.'
+            return
+
+        if len(ipy) == 4 and ipy[0] == bert.Atom('call'):
+            mod, fun, args = ipy[1:4]
+            self.log("-> " + ipy.__str__())
+            try:
+                res = self.dispatch(mod, fun, args)
+                opy = (bert.Atom('reply'), res)
+                self.log("<- " + opy.__str__())
+                self.write_berp(output, opy)
+            except ServerError, e:
+                opy = (bert.Atom('error'), (bert.Atom('server'), 0,
+                       str(type(e)), str(e), ''))
+                self.log("<- " + opy.__str__())
+                self.write_berp(output, opy)
+            except Exception, e:
+                opy = (bert.Atom('error'), (bert.Atom('user'), 0, str(type(e)),
+                       str(e), ''))
                 self.log("<- " + opy.__str__())
                 self.write_berp(output, opy)
 
+        elif len(ipy) == 4 and ipy[0] == bert.Atom('cast'):
+            mod, fun, args = ipy[1:4]
+            self.log("-> " + ipy.__str__())
+            try:
+                res = self.dispatch(mod, fun, args)
+            except:
+                pass
+            self.write_berp(output, (bert.Atom('noreply')))
+        else:
+            self.log("-> " + ipy.__str__())
+            opy = (bert.Atom('error'), (bert.Atom('server'), 0,
+                   "Invalid request: " + ipy.__str__()))
+            self.log("<- " + opy.__str__())
+            self.write_berp(output, opy)
+
+
 class ServerError(Exception):
+
     def __init__(self, value):
         self.value = value
+
     def __str__(self):
-        return repr(self.value)        
+        return repr(self.value)
+
 
 class Mod:
+
     def __init__(self, name):
         self.name = name
         self.funs = {}
-    
+
     def fun(self, name, func):
         self.funs[name] = func
+
+
+class ThreadedTCPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
+        pass
+
+
+class ThreadedErnie(object):
+    def start(self, daemon=False, host='', port=50007, kill_threads=False):
+        Ernie.log("Starting")
+        server = ThreadedTCPServer((host, port), ErnieTCPHandler)
+
+        # Start a thread with the server -- that thread will then start one
+        # more thread for each request
+        server_thread = threading.Thread(target=server.serve_forever)
+        # Exit the server thread when the main thread terminates
+        server_thread.daemon = daemon
+        # Kill all threads or wait for them to finnish on exit, False = wait
+        server_thread.daemon_threads = kill_threads
+        server_thread.start()
+        print "Server running..."

--- a/examples/calc-daemonized.py
+++ b/examples/calc-daemonized.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+from ernie import mod, start
+from time import sleep
+
+
+def calc_add(a, b):
+    return a + b
+
+
+def slowcalc_add(a, b):
+    sleep(2)
+    return a + b
+
+
+def slowcalc_superslow():
+    sleep(10)
+
+
+def errorcalc_add(a, b):
+    raise Exception("oops!")
+
+
+mod('calc').fun('add', calc_add)
+mod('slowcalc').fun('add', slowcalc_add)
+mod('slowcalc').fun('superslow', slowcalc_superslow)
+mod('errorcalc').fun('add', errorcalc_add)
+
+
+if __name__ == "__main__":
+    start(daemon=True)
+    while True:
+        sleep(100)

--- a/examples/calc-nondaemonized.py
+++ b/examples/calc-nondaemonized.py
@@ -1,22 +1,25 @@
 #!/usr/bin/env python
 
 from ernie import mod, start
-from ernie import Ernie
 from time import sleep
 
 
 def calc_add(a, b):
     return a + b
 
-def slowcalc_add(a,b):
+
+def slowcalc_add(a, b):
     sleep(2)
     return a + b
+
 
 def slowcalc_superslow():
     sleep(10)
 
-def errorcalc_add(a,b):
+
+def errorcalc_add(a, b):
     raise Exception("oops!")
+
 
 mod('calc').fun('add', calc_add)
 mod('slowcalc').fun('add', slowcalc_add)
@@ -24,4 +27,8 @@ mod('slowcalc').fun('superslow', slowcalc_superslow)
 mod('errorcalc').fun('add', errorcalc_add)
 
 if __name__ == "__main__":
+    ''' Starts the server.
+        WARNING: you will have to kill process to stop it as it
+                 will ignore Ctrl+C keyboard interrupts.
+    '''
     start()

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,11 @@ from distutils.core import setup
 # Ken's library version number depended on
 # the version number of python-bert. This is
 # not suitable for an automated installation
-# using pip which will automatically install 
+# using pip which will automatically install
 # the dependencies listed in 'install_requires'.
 # For this reason I manually set the version
 # number.
-__version__ = '2.0.0'
+__version__ = '2.1.0'
 
 setup(
     name = 'ernie',
@@ -29,7 +29,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
-    ], 
+    ],
     install_requires = ["bert>=2.0.0"],
     dependency_links = [
         'http://github.com/samuel/python-bert/tarball/master#egg=bert-2.0.0'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 # The original author of this library is
 # Ken Robertson ken@invalidlogic.com
 # This version is a fork on github maintained by
-# Andre Graf andre@dergraf.org.
+# Miguel Paolino miguel@paolino.com.uy.
 #
 # Ken's library version number depended on
 # the version number of python-bert. This is
@@ -14,15 +14,15 @@ from distutils.core import setup
 # the dependencies listed in 'install_requires'.
 # For this reason I manually set the version
 # number.
-__version__ = '1.0.0'
+__version__ = '2.0.0'
 
 setup(
     name = 'ernie',
     version = __version__,
     description = 'BERT-Ernie Library',
-    author = 'Ken Robertson',
-    author_email = 'ken@invalidlogic.com',
-    url = 'http://github.com/krobertson/python-ernie',
+    author = 'Miguel Paolino',
+    author_email = 'miguel@paolino.com.uy',
+    url = 'http://github.com/mpaolino/python-ernie',
     packages = ['ernie'],
     classifiers = [
         'Intended Audience :: Developers',


### PR DESCRIPTION
Hello, I've made a threaded version of your library, I'll be testing how much is gained using CPU intensive module calls (exported by ernie) compared to bertlet. It will be also nice to make some other changes to better separate the provided service and transport mechanism from the implemented RPC server among other things.
I'll personally prefer the familiar coroutine-way of doing things, but in my particular application of bertrpc, a threaded speaker recognition service (where CPU bond tasks are the norm) ernie seems to be a better alternative. 

Please let me know your thoughts. Thanks for your hard work!
