### PR TITLE
Add an optional parameter to start(): quiet_on_read_error

### DIFF
--- a/ernie/ernie.py
+++ b/ernie/ernie.py
@@ -63,7 +63,7 @@ class Ernie(object):
         output.write(data)
         output.flush()
 
-    def start(self, quiet_on_read_err=False):
+    def start(self, quiet_on_io_err=False):
         Ernie.log("Starting")
         # On windows nouse_stdio is ignored by Erlang at the port creation,
         # so we cannot use file descriptor 3 and 4 for communication.
@@ -75,7 +75,7 @@ class Ernie(object):
         while(True):
             ipy = self.read_berp(input)
             if ipy == None:
-                if not quiet_on_read_err:
+                if not quiet_on_io_err:
                     print ('Could not read BERP length header. '
                            'Ernie server may have gone away. '
                            'Exiting now.')
@@ -91,7 +91,7 @@ class Ernie(object):
                     try:
                         self.write_berp(output, opy)
                     except IOError as e:
-                        if quiet_on_read_err:
+                        if quiet_on_io_err:
                             exit()
                         else:
                             raise e
@@ -101,7 +101,7 @@ class Ernie(object):
                     try:
                         self.write_berp(output, opy)
                     except IOError as e:
-                        if quiet_on_read_err:
+                        if quiet_on_io_err:
                             exit()
                         else:
                             raise e
@@ -111,7 +111,7 @@ class Ernie(object):
                     try:
                         self.write_berp(output, opy)
                     except IOError as e:
-                        if quiet_on_read_err:
+                        if quiet_on_io_err:
                             exit()
                         else:
                             raise e
@@ -125,7 +125,7 @@ class Ernie(object):
                 try:
                     self.write_berp(output, (bert.Atom('noreply')))
                 except IOError as e:
-                    if quiet_on_read_err:
+                    if quiet_on_io_err:
                         exit()
                     else:
                         raise e
@@ -136,7 +136,7 @@ class Ernie(object):
                 try:
                     self.write_berp(output, opy)
                 except IOError as e:
-                    if quiet_on_read_err:
+                    if quiet_on_io_err:
                         exit()
                     else:
                         raise e

--- a/ernie/ernie.py
+++ b/ernie/ernie.py
@@ -92,7 +92,6 @@ class Ernie(object):
                         self.write_berp(output, opy)
                     except IOError as e:
                         if quiet_on_read_err:
-                            # quiet on read error
                             exit()
                         else:
                             raise e
@@ -103,7 +102,6 @@ class Ernie(object):
                         self.write_berp(output, opy)
                     except IOError as e:
                         if quiet_on_read_err:
-                            # quiet on read error
                             exit()
                         else:
                             raise e
@@ -114,7 +112,6 @@ class Ernie(object):
                         self.write_berp(output, opy)
                     except IOError as e:
                         if quiet_on_read_err:
-                            # quiet on read error
                             exit()
                         else:
                             raise e
@@ -129,7 +126,6 @@ class Ernie(object):
                     self.write_berp(output, (bert.Atom('noreply')))
                 except IOError as e:
                     if quiet_on_read_err:
-                        # quiet on read error
                         exit()
                     else:
                         raise e
@@ -141,7 +137,6 @@ class Ernie(object):
                     self.write_berp(output, opy)
                 except IOError as e:
                     if quiet_on_read_err:
-                        # quiet on read error
                         exit()
                     else:
                         raise e


### PR DESCRIPTION
Hi Ken,

This PR prevents to pollute the parent process output when the port has been closed by the erlang process.

This is implemented with an optional parameter in start() method.
In order to not change the API I chose to duplicate the try/except in start() method.

Other cleaner method may have been chosen but I need Linux and Windows compatibility.

Cheers,
syl20bnr
